### PR TITLE
Fixed button misalignment in Platform Services cards on Landing page.

### DIFF
--- a/frontend/src/components/landing/landing-page.tsx
+++ b/frontend/src/components/landing/landing-page.tsx
@@ -514,7 +514,7 @@ export default function LandingPage() {
             ].map((service, index) => (
               <div
                 key={index}
-                className={`group bg-gradient-to-br from-slate-800/60 to-slate-900/60 backdrop-blur-xl rounded-3xl p-10 border border-white/10 hover:border-cyan-400/30 transition-all duration-500 hover:scale-105 hover:shadow-2xl glow-subtle ${isVisible.services ? `animate-fade-in-up` : 'opacity-0'
+                className={`flex flex-col group bg-gradient-to-br from-slate-800/60 to-slate-900/60 backdrop-blur-xl rounded-3xl p-10 border border-white/10 hover:border-cyan-400/30 transition-all duration-500 hover:scale-105 hover:shadow-2xl glow-subtle ${isVisible.services ? `animate-fade-in-up` : 'opacity-0'
                   }`}
                 style={{ animationDelay: `${index * 0.2}s` }}
                 data-animate
@@ -531,23 +531,25 @@ export default function LandingPage() {
                   {service.description}
                 </p>
 
-                <ul className="space-y-4 mb-8">
-                  {service.features.map((feature, idx) => (
-                    <li key={idx} className="flex items-center text-gray-300 group-hover:text-gray-200 transition-colors duration-300">
-                      <CheckCircle className="h-5 w-5 text-cyan-400 mr-3 group-hover:text-cyan-300" />
-                      <span className="text-base">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                <Button
-                  variant="outline"
-                  onClick={handleLaunchPlatform}
-                  className="w-full border-2 border-cyan-400/50 text-cyan-400 hover:bg-cyan-400/10 hover:border-cyan-400 py-3 rounded-2xl font-semibold transition-all duration-300 hover:scale-105"
-                >
-                  Explore {service.title}
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Button>
+                <div className="mt-auto">
+                  <ul className="space-y-4 mb-8">
+                    {service.features.map((feature, idx) => (
+                      <li key={idx} className="flex items-center text-gray-300 group-hover:text-gray-200 transition-colors duration-300">
+                        <CheckCircle className="h-5 w-5 text-cyan-400 mr-3 group-hover:text-cyan-300" />
+                        <span className="text-base">{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+  
+                  <Button
+                    variant="outline"
+                    onClick={handleLaunchPlatform}
+                    className="w-full border-2 border-cyan-400/50 text-cyan-400 hover:bg-cyan-400/10 hover:border-cyan-400 py-3 rounded-2xl font-semibold transition-all duration-300 hover:scale-105"
+                  >
+                    Explore {service.title}
+                    <ArrowRight className="ml-2 h-5 w-5" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Description

Previously, the Explore buttons at the bottom of each Platform Services card (e.g., "Explore AI Health Analytics") were not horizontally aligned, especially when the card content (like descriptions or feature lists) varied in length. 

This PR implements a Flexbox-based layout fix to ensure all cards maintain consistent vertical alignment of their bottom elements.

## Key Changes

Applied flex flex-col to each card container.
Wrapped the features list and button in a div className="mt-auto" to push this block to the bottom of the card.

This approach ensures that:

- All cards grow naturally based on their content.
- The button is always aligned to the bottom, regardless of description/feature count.
- The layout remains fully responsive and adaptive across devices and screen sizes.

## Result

- All "Explore" buttons are now aligned across the grid layout.
- Maintains accessibility and responsiveness.
- No need for fixed heights — keeping the layout dynamic and scalable.

## Screenshot
<img width="1773" height="753" alt="cura-genie fixed cards" src="https://github.com/user-attachments/assets/8162cd39-a304-493b-8aa1-f4365d247221" />

## Additional Info
Closes #78 

Kindly review and merge this PR @harshguptakiet and add the level 2 label.