### PR TITLE
Replace Role Selection Radio Buttons with Dropdown

### DIFF
--- a/frontend/src/components/auth/auth-form.tsx
+++ b/frontend/src/components/auth/auth-form.tsx
@@ -247,31 +247,24 @@ export function AuthForm({ initialMode = 'login', resetToken }: AuthFormProps) {
             {/* Role Selection (Register only) */}
             {mode === 'register' && (
               <div className="space-y-2">
-                <label className="text-sm font-medium">I am a:</label>
-                <div className="flex gap-4">
-                  <label className="flex items-center space-x-2 cursor-pointer">
-                    <input
-                      type="radio"
-                      name="role"
-                      value="patient"
-                      checked={formData.role === 'patient'}
-                      onChange={(e) => updateFormData('role', e.target.value)}
-                      className="text-blue-600"
-                    />
-                    <span className="text-sm">Patient</span>
-                  </label>
-                  <label className="flex items-center space-x-2 cursor-pointer">
-                    <input
-                      type="radio"
-                      name="role"
-                      value="doctor"
-                      checked={formData.role === 'doctor'}
-                      onChange={(e) => updateFormData('role', e.target.value)}
-                      className="text-blue-600"
-                    />
-                    <span className="text-sm">Doctor</span>
-                  </label>
+                <div className="relative">
+                  <User className="absolute left-3 top-3 h-4 w-4 text-gray-500" />
+                  <select
+                    name="role"
+                    value={formData.role}
+                    onChange={(e) => updateFormData('role', e.target.value)}
+                    className={`w-full rounded-md border border-gray-300 pl-10 pr-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                      !formData.role ? 'text-gray-500' : 'text-gray-500'
+                    }`}
+                  >
+                    <option value="" disabled>
+                      Select Role
+                    </option>
+                    <option value="patient">Patient</option>
+                    <option value="doctor">Doctor</option>
+                  </select>
                 </div>
+                {errors.role && <p className="text-sm text-red-500">{errors.role}</p>}
               </div>
             )}
 


### PR DESCRIPTION
## Related Issue:
Closes #85 

## Summary of Changes:
- Replaced the existing radio button implementation for role selection with a dropdown menu.
- Added the following role options:
      - Patient
      - Doctor
- Applied styling to ensure the dropdown matches the form’s design system (icons, placeholder text, border, and colors).
- Updated validation logic to handle dropdown input.

## Rationale:
1. A dropdown provides a cleaner and more compact interface.
2. It is easily scalable, allowing future roles (e.g., Nurse, Admin, Researcher) to be added with minimal changes.
3. Improves user experience and aligns with standard form design practices.

## Expected Outcome
1. Users will now select their role from a dropdown instead of radio buttons.
2. This ensures a more intuitive, scalable, and uniform design across the account creation form.

## Screenshot:
<img width="1903" height="907" alt="image" src="https://github.com/user-attachments/assets/fb0b7e53-f32f-4d98-a03c-40460e9718c2" />

## Additional Context:
Kindly review and merge the PR. @harshguptakiet 